### PR TITLE
Use Romaji Lyrics when avaible with Genius toggle.

### DIFF
--- a/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
@@ -104,22 +104,26 @@ struct GeniusLyricsRepository: LyricsRepository {
     
     func getLyrics(_ query: LyricsSearchQuery) throws -> LyricsDto {
         let strippedTitle = query.title.strippedTrackTitle
-        let romanizedQuery = "\(strippedTitle) \(query.primaryArtist) (Romanized)"
-        let defaultQuery = "\(strippedTitle) \(query.primaryArtist)"
+        let queries = [
+            "\(strippedTitle) \(query.primaryArtist) (Romanized)",
+            "\(strippedTitle) \(query.primaryArtist)"
+        ]
     
         var hits: [GeniusHit] = []
     
-        do {
-            hits = try searchSong(romanizedQuery)
-        } catch {
+        for searchQuery in queries {
             do {
-                hits = try searchSong(defaultQuery)
+                hits = try searchSong(searchQuery)
+                if !hits.isEmpty {
+                    break
+                }
             } catch {
-                hits = try searchSong("\(strippedTitle) \(query.primaryArtist)")
+                // Continue to the next query if the current one fails
             }
         }
     
-        guard let song = mostRelevantHitResult(hits: hits, strippedTitle: strippedTitle) else {
+        guard !hits.isEmpty,
+              let song = mostRelevantHitResult(hits: hits, strippedTitle: strippedTitle) else {
             throw LyricsError.NoSuchSong
         }
     

--- a/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
@@ -104,6 +104,7 @@ struct GeniusLyricsRepository: LyricsRepository {
     
     func getLyrics(_ query: LyricsSearchQuery) throws -> LyricsDto {
         let strippedTitle = query.title.strippedTrackTitle
+        let queries = []
         if UserDefaults.romanizedLyrics {
             let queries = [
                 "\(strippedTitle) \(query.primaryArtist) (Romanized)",

--- a/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
@@ -104,10 +104,16 @@ struct GeniusLyricsRepository: LyricsRepository {
     
     func getLyrics(_ query: LyricsSearchQuery) throws -> LyricsDto {
         let strippedTitle = query.title.strippedTrackTitle
-        let queries = [
-            "\(strippedTitle) \(query.primaryArtist) (Romanized)",
-            "\(strippedTitle) \(query.primaryArtist)"
-        ]
+        if UserDefaults.romanizedLyrics {
+            let queries = [
+                "\(strippedTitle) \(query.primaryArtist) (Romanized)",
+                "\(strippedTitle) \(query.primaryArtist)"
+            ]
+        } else {
+            let queries = [
+                "\(strippedTitle) \(query.primaryArtist)"
+            ]
+        }
     
         var hits: [GeniusHit] = []
     

--- a/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
@@ -104,18 +104,16 @@ struct GeniusLyricsRepository: LyricsRepository {
     
     func getLyrics(_ query: LyricsSearchQuery) throws -> LyricsDto {
         let strippedTitle = query.title.strippedTrackTitle
-        let queries = []
+        var queries = [
+            "\(strippedTitle) \(query.primaryArtist)"
+        ]
+        
         if UserDefaults.romanizedLyrics {
-            let queries = [
+            queries = [
                 "\(strippedTitle) \(query.primaryArtist) (Romanized)",
                 "\(strippedTitle) \(query.primaryArtist)"
             ]
-        } else {
-            let queries = [
-                "\(strippedTitle) \(query.primaryArtist)"
-            ]
         }
-    
         var hits: [GeniusHit] = []
     
         for searchQuery in queries {

--- a/Sources/EeveeSpotify/Models/Extensions/UserDefaults+Extension.swift
+++ b/Sources/EeveeSpotify/Models/Extensions/UserDefaults+Extension.swift
@@ -7,6 +7,7 @@ extension UserDefaults {
     private static let lyricsSourceKey = "lyricsSource"
     private static let musixmatchTokenKey = "musixmatchToken"
     private static let geniusFallbackKey = "geniusFallback"
+    private static let romanizedLyricsKey = "romanizedLyrics"
     private static let fallbackReasonsKey = "fallbackReasons"
     private static let darkPopUpsKey = "darkPopUps"
     private static let patchTypeKey = "patchType"
@@ -41,6 +42,15 @@ extension UserDefaults {
         }
         set (fallback) {
             defaults.set(fallback, forKey: geniusFallbackKey)
+        }
+    }
+
+    static var romanizedLyrics: Bool {
+        get {
+            defaults.object(forKey: romanizedLyricsKey) as? Bool ?? true
+        }
+        set (romanized) {
+            defaults.set(romanized, forKey: romanizedLyricsKey)
         }
     }
     

--- a/Sources/EeveeSpotify/Models/Extensions/UserDefaults+Extension.swift
+++ b/Sources/EeveeSpotify/Models/Extensions/UserDefaults+Extension.swift
@@ -47,7 +47,7 @@ extension UserDefaults {
 
     static var romanizedLyrics: Bool {
         get {
-            defaults.object(forKey: romanizedLyricsKey) as? Bool ?? true
+            defaults.object(forKey: romanizedLyricsKey) as? Bool ?? false
         }
         set (romanized) {
             defaults.set(romanized, forKey: romanizedLyricsKey)

--- a/Sources/EeveeSpotify/Settings/Views/EeveeSettingsViewController+LyricsSections.swift
+++ b/Sources/EeveeSpotify/Settings/Views/EeveeSettingsViewController+LyricsSections.swift
@@ -105,10 +105,8 @@ If the tweak is unable to find a song or process the lyrics, you'll see a "Could
             UserDefaults.lyricsSource = newSource
         }
         
-        if lyricsSource = .genius {
-            Section(
-                footer: Text("Load lyrics from Genius if there is a problem with \(lyricsSource).")
-            ) {
+        if lyricsSource == .genius {
+            Section {
                 Toggle(
                     "Use Romanized (Romaji) Lyrics when Available",
                     isOn: Binding<Bool>(
@@ -117,6 +115,7 @@ If the tweak is unable to find a song or process the lyrics, you'll see a "Could
                     )
                 )
             }
+        }
 
         if lyricsSource != .genius {
             Section(

--- a/Sources/EeveeSpotify/Settings/Views/EeveeSettingsViewController+LyricsSections.swift
+++ b/Sources/EeveeSpotify/Settings/Views/EeveeSettingsViewController+LyricsSections.swift
@@ -124,6 +124,13 @@ If the tweak is unable to find a song or process the lyrics, you'll see a "Could
                         set: { UserDefaults.fallbackReasons = $0 }
                     )
                 )
+                Toggle(
+                    "Use Romanized (Romaji) Lyrics when Available",
+                    isOn: Binding<Bool>(
+                        get: { UserDefaults.romanizedLyrics },
+                        set: { UserDefaults.romanizedLyrics = $0 }
+                    )
+                )
             }
         }
     }

--- a/Sources/EeveeSpotify/Settings/Views/EeveeSettingsViewController+LyricsSections.swift
+++ b/Sources/EeveeSpotify/Settings/Views/EeveeSettingsViewController+LyricsSections.swift
@@ -104,6 +104,19 @@ If the tweak is unable to find a song or process the lyrics, you'll see a "Could
 
             UserDefaults.lyricsSource = newSource
         }
+        
+        if lyricsSource = .genius {
+            Section(
+                footer: Text("Load lyrics from Genius if there is a problem with \(lyricsSource).")
+            ) {
+                Toggle(
+                    "Use Romanized (Romaji) Lyrics when Available",
+                    isOn: Binding<Bool>(
+                        get: { UserDefaults.romanizedLyrics },
+                        set: { UserDefaults.romanizedLyrics = $0 }
+                    )
+                )
+            }
 
         if lyricsSource != .genius {
             Section(
@@ -122,13 +135,6 @@ If the tweak is unable to find a song or process the lyrics, you'll see a "Could
                     isOn: Binding<Bool>(
                         get: { UserDefaults.fallbackReasons },
                         set: { UserDefaults.fallbackReasons = $0 }
-                    )
-                )
-                Toggle(
-                    "Use Romanized (Romaji) Lyrics when Available",
-                    isOn: Binding<Bool>(
-                        get: { UserDefaults.romanizedLyrics },
-                        set: { UserDefaults.romanizedLyrics = $0 }
                     )
                 )
             }


### PR DESCRIPTION
Closes https://github.com/whoeevee/EeveeSpotify/issues/225
Adds a switch in settings to enable ```UserDefaults.romanizedLyrics```.
Reworked Genius quarrying logic, to allow for multiple search attempts. This will also allow for multiple quary formats if needed/wanted.
if ```UserDefaults.romanizedLyrics``` is enabled first search for "\(strippedTitle) \(query.primaryArtist) (Romanized)" when using Genius, if that throws an error, and fallback to "\(strippedTitle) \(query.primaryArtist)".

**Currently nothing is preventing the Romanized quary from being used if Genius is triggered as a fallback from another source, this could be easily added, but I was unsure if it is wanted...**