### PR TITLE
Romanized MusixMatch Lyrics

### DIFF
--- a/Sources/EeveeSpotify/Lyrics/Models/Settings/LyricsOptions.swift
+++ b/Sources/EeveeSpotify/Lyrics/Models/Settings/LyricsOptions.swift
@@ -2,4 +2,5 @@ import Foundation
 
 struct LyricsOptions: Codable, Equatable {
     var geniusRomanizations: Bool
+    var musixmatchRomanizations: Bool
 }

--- a/Sources/EeveeSpotify/Models/Extensions/UserDefaults+Extension.swift
+++ b/Sources/EeveeSpotify/Models/Extensions/UserDefaults+Extension.swift
@@ -51,7 +51,7 @@ extension UserDefaults {
                 return try! JSONDecoder().decode(LyricsOptions.self, from: data)
             }
             
-            return LyricsOptions(geniusRomanizations: false)
+            return LyricsOptions(geniusRomanizations: false, musixmatchRomanizations: false)
         }
         set (lyricsOptions) {
             defaults.set(try! JSONEncoder().encode(lyricsOptions), forKey: lyricsOptionsKey)

--- a/Sources/EeveeSpotify/Settings/Views/EeveeSettingsViewController+LyricsOptionsSection.swift
+++ b/Sources/EeveeSpotify/Settings/Views/EeveeSettingsViewController+LyricsOptionsSection.swift
@@ -13,5 +13,16 @@ extension EeveeSettingsView {
                 UserDefaults.lyricsOptions = lyricsOptions
             }
         }
+        if lyricsSource == .musixmatch {
+            Section {
+                Toggle(
+                    "Romanized MusixMatch Lyrics",
+                    isOn: $lyricsOptions.musixmatchRomanizations
+                )
+            }
+            .onChange(of: lyricsOptions) { lyricsOptions in
+                UserDefaults.lyricsOptions = lyricsOptions
+            }
+        }
     }
 }


### PR DESCRIPTION
Added a switch to settings (in Lyric Options) for "Romanized MusixMatch Lyrics" when enabled, it will fetch the Romanized lyric translations for each song and replace the translated parts, when using MusixMatch Source.

- Add switch in EeveeSettingsViewController+LyricsOptionsSection.swift to enable UserDefaults.lyricsOptions.musixmatchRomanizations
- Add necessary code for UserDefaults.lyricsOptions.musixmatchRomanizations to work (edited Settings/LyricsOptions.swift and UserDefaults+Extension.swift)

In MusixMatch repository:
- Introduced checks for UserDefaults.lyricsOptions.musixmatchRomanizations to determine if Romanized lyrics should be fetched.
- Updated logic in both subtitle (time synced lyrics) and plain lyrics (non-time synced lyrics) handling to fetch and integrate Romanized translations when required.
- Added API call to "/ws/1.1/crowd.track.translations.get" to retrieve Romanized translations.
- Included logic to process the translation data and integrate it with the existing plain lyrics or subtitles.
- If anything fails with Romanized lyrics, fallback to default behavior without translation.