### PR TITLE
Add PetitLyric Source

### DIFF
--- a/Sources/EeveeSpotify/Lyrics/CustomLyrics.x.swift
+++ b/Sources/EeveeSpotify/Lyrics/CustomLyrics.x.swift
@@ -147,6 +147,7 @@ func getCurrentTrackLyricsData(originalLyrics: Lyrics? = nil) throws -> Data {
         case .genius: GeniusLyricsRepository()
         case .lrclib: LrcLibLyricsRepository()
         case .musixmatch: MusixmatchLyricsRepository.shared
+        case .petitLyrics: PetitLyricsRepository()
     }
     
     let lyricsDto: LyricsDto

--- a/Sources/EeveeSpotify/Lyrics/Models/Settings/LyricsSource.swift
+++ b/Sources/EeveeSpotify/Lyrics/Models/Settings/LyricsSource.swift
@@ -4,12 +4,14 @@ enum LyricsSource : Int, CustomStringConvertible {
     case genius
     case lrclib
     case musixmatch
+    case petitLyrics
 
     var description : String { 
         switch self {
         case .genius: "Genius"
         case .lrclib: "LRCLIB"
         case .musixmatch: "Musixmatch"
+        case .petitLyrics: "Petit Lyrics"
         }
     }
 }

--- a/Sources/EeveeSpotify/Lyrics/Repositories/PetitLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/PetitLyricsRepository.swift
@@ -1,28 +1,94 @@
 import Foundation
 
+class XMLDictionaryParser: NSObject, XMLParserDelegate {
+    private var dictionaryStack: [[String: Any]] = []
+    private var textInProgress: String = ""
+    
+    func parse(data: Data) -> [String: Any]? {
+        let parser = XMLParser(data: data)
+        parser.delegate = self
+        guard parser.parse() else {
+            NSLog("[EeveeSpotify] Failed to parse XML")
+            return nil
+        }
+        return dictionaryStack.first
+    }
+
+    // MARK: - XMLParserDelegate
+
+    func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String]) {
+        var dict: [String: Any] = [:]
+        for (key, value) in attributeDict {
+            if let intValue = Int(value) {
+                dict[key] = intValue
+            } else {
+                dict[key] = value
+            }
+        }
+        dictionaryStack.append(dict)
+        textInProgress = ""
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        textInProgress += string
+    }
+
+    func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
+        var dict = dictionaryStack.popLast()!
+        if !textInProgress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if let intValue = Int(textInProgress.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                dict[elementName] = intValue
+            } else {
+                dict[elementName] = textInProgress.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        
+        if var top = dictionaryStack.last {
+            if let existingValue = top[elementName] {
+                if var array = existingValue as? [[String: Any]] {
+                    array.append(dict)
+                    top[elementName] = array
+                } else {
+                    top[elementName] = [existingValue, dict]
+                }
+            } else if dict.count == 1, let key = dict.keys.first, let value = dict[key] {
+                top[elementName] = value
+            } else {
+                top[elementName] = dict
+            }
+            dictionaryStack[dictionaryStack.count - 1] = top
+        } else {
+            dictionaryStack.append(dict)
+        }
+        textInProgress = ""
+        NSLog("[EeveeSpotify] End Element: \(elementName), dictionary: \(dict)")
+    }
+}
+
 struct PetitLyricsRepository: LyricsRepository {
-    private let searchUrl = "https://petitlyrics.com/search_lyrics"
-    private let csrfUrl = "https://petitlyrics.com/lib/pl-lib.js"
-    private let lyricsUrl = "https://petitlyrics.com/com/get_lyrics.ajax"
+    private let apiUrl = "https://p1.petitlyrics.com/api/GetPetitLyricsData.php"
     private let session: URLSession
 
     init() {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = [
+            "Content-Type": "application/x-www-form-urlencoded",
             "User-Agent": "EeveeSpotify v\(EeveeSpotify.version) https://github.com/whoeevee/EeveeSpotify"
         ]
+        
         session = URLSession(configuration: configuration)
     }
-
-    private func perform(_ url: String, method: String = "GET", headers: [String: String] = [:], body: [String: String] = [:]) throws -> Data {
-        var request = URLRequest(url: URL(string: url)!)
-        request.httpMethod = method
-        request.allHTTPHeaderFields = headers
-
-        if method == "POST" {
-            request.httpBody = body.queryString.data(using: .utf8)
-        }
-
+    
+    private func perform(
+        _ query: [String: Any]
+    ) throws -> Data {
+        NSLog("[EeveeSpotify] Perform Func")
+        var request = URLRequest(url: URL(string: apiUrl)!)
+        request.httpMethod = "POST"
+        
+        let queryString = query.queryString
+        request.httpBody = queryString.data(using: .utf8)
+        
         let semaphore = DispatchSemaphore(value: 0)
         var data: Data?
         var error: Error?
@@ -42,63 +108,107 @@ struct PetitLyricsRepository: LyricsRepository {
 
         return data!
     }
-
-    private func extractLyricId(from html: String) -> String? {
-        let regex = try! NSRegularExpression(pattern: "/lyrics/(\\d+)")
-        let range = NSRange(location: 0, length: html.utf16.count)
-        if let match = regex.firstMatch(in: html, options: [], range: range) {
-            if let range = Range(match.range(at: 1), in: html) {
-                return String(html[range])
-            }
+    
+    private func decodeBase64(_ base64String: String) throws -> Data {
+        NSLog("[EeveeSpotify] Decoding Base64")
+        guard let data = Data(base64Encoded: base64String) else {
+            throw LyricsError.DecodingError
         }
-        return nil
+        return data
     }
-
-    private func extractCsrfToken(from js: String) -> String? {
-        let regex = try! NSRegularExpression(pattern: "X-CSRF-Token',\\s*'([^']+)'")
-        let range = NSRange(location: 0, length: js.utf16.count)
-        if let match = regex.firstMatch(in: js, options: [], range: range) {
-            if let range = Range(match.range(at: 1), in: js) {
-                return String(js[range])
-            }
+    
+    private func mapTimeSyncedLyrics(_ xmlData: Data) throws -> [LyricsLineDto] {
+        NSLog("[EeveeSpotify] Mapping Time synced (wsy)")
+        guard let parsedDictionary = XMLDictionaryParser().parse(data: xmlData),
+              let lines = parsedDictionary["line"] as? [[String: Any]] else {
+            throw LyricsError.DecodingError
         }
-        return nil
+        
+        var lyricsLines: [LyricsLineDto] = []
+        NSLog("[EeveeSpotify] Mapping Time synced (Lines)")
+        for line in lines {
+            guard let lineString = line["linestring"] as? String,
+                  let words = line["word"] as? [[String: Any]],
+                  let firstWord = words.first,
+                  let startTimeInt = firstWord["starttime"] as? Int else {
+                  continue // Skip lines that don't have necessary data
+            }
+            
+            let lyricsLineDto = LyricsLineDto(content: lineString, offsetMs: startTimeInt)
+            lyricsLines.append(lyricsLineDto)
+        }
+        
+        return lyricsLines
     }
-
+    
     func getLyrics(_ query: LyricsSearchQuery, options: LyricsOptions) throws -> LyricsDto {
-        let searchData = ["title": query.title, "artist": query.primaryArtist]
-        let searchResponse = try perform(searchUrl, method: "POST", headers: ["Content-Type": "application/x-www-form-urlencoded"], body: searchData)
-        guard let lyricId = extractLyricId(from: String(data: searchResponse, encoding: .utf8)!) else {
+        NSLog("[EeveeSpotify] getLyrics")
+        var petitLyricsQuery = [
+            "maxCount": "1",
+            "key_title": query.title,
+            "key_artist": query.primaryArtist,
+            "terminalType": "10",
+            "clientAppId": "p1232089",
+            "lyricsType": "3"
+        ]
+        
+        let response = try perform(petitLyricsQuery)
+        let parser = XMLDictionaryParser()
+        let parsedDictionary = parser.parse(data: response)
+        
+        guard let parsedDict = parsedDictionary,
+              let songs = parsedDict["songs"] as? [String: Any],
+              let song = songs["song"] as? [String: Any] else {
             throw LyricsError.NoSuchSong
         }
 
-        let initialUrl = "https://petitlyrics.com/lyrics/\(lyricId)"
-        _ = try perform(initialUrl)
-
-        let csrfResponse = try perform(csrfUrl)
-        guard let csrfToken = extractCsrfToken(from: String(data: csrfResponse, encoding: .utf8)!) else {
+        
+        guard let lyricsDataBase64 = song["lyricsData"] as? String,
+              let lyricsType = song["lyricsType"] as? Int else {
             throw LyricsError.DecodingError
         }
+        
 
-        let cookies = HTTPCookieStorage.shared.cookies?.first(where: { $0.name == "PLSESSION" })
-        guard let plsessionCookie = cookies?.value else {
-            throw LyricsError.DecodingError
+        let lyricsData = try decodeBase64(lyricsDataBase64)
+        
+        if lyricsType == 2 {
+            petitLyricsQuery["lyricsType"] = "1"
+            let responsetype1 = try perform(petitLyricsQuery)
+            let parser = XMLDictionaryParser()
+            guard let parsedDictionary1 = parser.parse(data: responsetype1) else {
+                throw LyricsError.DecodingError
+            }
+            
+            guard let songs = parsedDictionary1["songs"] as? [String: Any],
+                  let song = songs["song"] as? [String: Any],
+                  let lyricsDataBase64 = song["lyricsData"] as? String else {
+                throw LyricsError.DecodingError
+            }
+            
+            let lyricsData = try decodeBase64(lyricsDataBase64)
+            let lines = String(data: lyricsData, encoding: .utf8)?
+                .components(separatedBy: "\n")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .map { LyricsLineDto(content: $0) } ?? []
+            return LyricsDto(lines: lines, timeSynced: false)
         }
+        
+        if lyricsType == 1 {
+            let lines = String(data: lyricsData, encoding: .utf8)?
+                .components(separatedBy: "\n")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .map { LyricsLineDto(content: $0) } ?? []
+            return LyricsDto(lines: lines, timeSynced: false)
 
-        let lyricsData = ["lyrics_id": lyricId]
-        let lyricsResponse = try perform(lyricsUrl, method: "POST", headers: [
-            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-            "Cookie": "PLSESSION=\(plsessionCookie)",
-            "X-CSRF-Token": csrfToken,
-            "X-Requested-With": "XMLHttpRequest"
-        ], body: lyricsData)
-
-        let lyricsJson = try JSONSerialization.jsonObject(with: lyricsResponse, options: []) as! [[String: Any]]
-        let lyricsLines = lyricsJson.map { item -> LyricsLineDto in
-            let decodedLyrics = String(data: Data(base64Encoded: item["lyrics"] as! String)!, encoding: .utf8)!
-            return LyricsLineDto(content: decodedLyrics)
         }
-
-        return LyricsDto(lines: lyricsLines, timeSynced: false)
+        
+        if lyricsType == 3 {
+            let lines = try mapTimeSyncedLyrics(lyricsData)
+            return LyricsDto(lines: lines, timeSynced: true)
+        }
+        
+        throw LyricsError.DecodingError
     }
 }

--- a/Sources/EeveeSpotify/Lyrics/Repositories/PetitLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/PetitLyricsRepository.swift
@@ -61,7 +61,6 @@ class XMLDictionaryParser: NSObject, XMLParserDelegate {
             dictionaryStack.append(dict)
         }
         textInProgress = ""
-        NSLog("[EeveeSpotify] End Element: \(elementName), dictionary: \(dict)")
     }
 }
 
@@ -82,7 +81,6 @@ struct PetitLyricsRepository: LyricsRepository {
     private func perform(
         _ query: [String: Any]
     ) throws -> Data {
-        NSLog("[EeveeSpotify] Perform Func")
         var request = URLRequest(url: URL(string: apiUrl)!)
         request.httpMethod = "POST"
         
@@ -110,7 +108,6 @@ struct PetitLyricsRepository: LyricsRepository {
     }
     
     private func decodeBase64(_ base64String: String) throws -> Data {
-        NSLog("[EeveeSpotify] Decoding Base64")
         guard let data = Data(base64Encoded: base64String) else {
             throw LyricsError.DecodingError
         }
@@ -118,14 +115,12 @@ struct PetitLyricsRepository: LyricsRepository {
     }
     
     private func mapTimeSyncedLyrics(_ xmlData: Data) throws -> [LyricsLineDto] {
-        NSLog("[EeveeSpotify] Mapping Time synced (wsy)")
         guard let parsedDictionary = XMLDictionaryParser().parse(data: xmlData),
               let lines = parsedDictionary["line"] as? [[String: Any]] else {
             throw LyricsError.DecodingError
         }
         
         var lyricsLines: [LyricsLineDto] = []
-        NSLog("[EeveeSpotify] Mapping Time synced (Lines)")
         for line in lines {
             guard let lineString = line["linestring"] as? String,
                   let words = line["word"] as? [[String: Any]],
@@ -142,7 +137,6 @@ struct PetitLyricsRepository: LyricsRepository {
     }
     
     func getLyrics(_ query: LyricsSearchQuery, options: LyricsOptions) throws -> LyricsDto {
-        NSLog("[EeveeSpotify] getLyrics")
         var petitLyricsQuery = [
             "maxCount": "1",
             "key_title": query.title,

--- a/Sources/EeveeSpotify/Lyrics/Repositories/PetitLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/PetitLyricsRepository.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+struct PetitLyricsRepository: LyricsRepository {
+    private let searchUrl = "https://petitlyrics.com/search_lyrics"
+    private let csrfUrl = "https://petitlyrics.com/lib/pl-lib.js"
+    private let lyricsUrl = "https://petitlyrics.com/com/get_lyrics.ajax"
+    private let session: URLSession
+
+    init() {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = [
+            "User-Agent": "EeveeSpotify v\(EeveeSpotify.version) https://github.com/whoeevee/EeveeSpotify"
+        ]
+        session = URLSession(configuration: configuration)
+    }
+
+    private func perform(_ url: String, method: String = "GET", headers: [String: String] = [:], body: [String: String] = [:]) throws -> Data {
+        var request = URLRequest(url: URL(string: url)!)
+        request.httpMethod = method
+        request.allHTTPHeaderFields = headers
+
+        if method == "POST" {
+            request.httpBody = body.queryString.data(using: .utf8)
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var data: Data?
+        var error: Error?
+
+        let task = session.dataTask(with: request) { response, _, err in
+            error = err
+            data = response
+            semaphore.signal()
+        }
+
+        task.resume()
+        semaphore.wait()
+
+        if let error = error {
+            throw error
+        }
+
+        return data!
+    }
+
+    private func extractLyricId(from html: String) -> String? {
+        let regex = try! NSRegularExpression(pattern: "/lyrics/(\\d+)")
+        let range = NSRange(location: 0, length: html.utf16.count)
+        if let match = regex.firstMatch(in: html, options: [], range: range) {
+            if let range = Range(match.range(at: 1), in: html) {
+                return String(html[range])
+            }
+        }
+        return nil
+    }
+
+    private func extractCsrfToken(from js: String) -> String? {
+        let regex = try! NSRegularExpression(pattern: "X-CSRF-Token',\\s*'([^']+)'")
+        let range = NSRange(location: 0, length: js.utf16.count)
+        if let match = regex.firstMatch(in: js, options: [], range: range) {
+            if let range = Range(match.range(at: 1), in: js) {
+                return String(js[range])
+            }
+        }
+        return nil
+    }
+
+    func getLyrics(_ query: LyricsSearchQuery, options: LyricsOptions) throws -> LyricsDto {
+        let searchData = ["title": query.title, "artist": query.primaryArtist]
+        let searchResponse = try perform(searchUrl, method: "POST", headers: ["Content-Type": "application/x-www-form-urlencoded"], body: searchData)
+        guard let lyricId = extractLyricId(from: String(data: searchResponse, encoding: .utf8)!) else {
+            throw LyricsError.NoSuchSong
+        }
+
+        let initialUrl = "https://petitlyrics.com/lyrics/\(lyricId)"
+        _ = try perform(initialUrl)
+
+        let csrfResponse = try perform(csrfUrl)
+        guard let csrfToken = extractCsrfToken(from: String(data: csrfResponse, encoding: .utf8)!) else {
+            throw LyricsError.DecodingError
+        }
+
+        let cookies = HTTPCookieStorage.shared.cookies?.first(where: { $0.name == "PLSESSION" })
+        guard let plsessionCookie = cookies?.value else {
+            throw LyricsError.DecodingError
+        }
+
+        let lyricsData = ["lyrics_id": lyricId]
+        let lyricsResponse = try perform(lyricsUrl, method: "POST", headers: [
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "Cookie": "PLSESSION=\(plsessionCookie)",
+            "X-CSRF-Token": csrfToken,
+            "X-Requested-With": "XMLHttpRequest"
+        ], body: lyricsData)
+
+        let lyricsJson = try JSONSerialization.jsonObject(with: lyricsResponse, options: []) as! [[String: Any]]
+        let lyricsLines = lyricsJson.map { item -> LyricsLineDto in
+            let decodedLyrics = String(data: Data(base64Encoded: item["lyrics"] as! String)!, encoding: .utf8)!
+            return LyricsLineDto(content: decodedLyrics)
+        }
+
+        return LyricsDto(lines: lyricsLines, timeSynced: false)
+    }
+}

--- a/Sources/EeveeSpotify/Settings/Views/Sections/EeveeLyricsSettingsView+LyricsSourceSection.swift
+++ b/Sources/EeveeSpotify/Settings/Views/Sections/EeveeLyricsSettingsView+LyricsSourceSection.swift
@@ -12,6 +12,8 @@ LRCLIB: The most open service, offering time-synced lyrics. However, it lacks ly
 
 Musixmatch: The service Spotify uses. Provides time-synced lyrics for many songs, but you'll need a user token to use this source.
 
+Petit Lyrics: Provides lyrics from Petit Lyrics. Mostly has Japanese song lyrics. Does not provide time-synced lyrics.
+
 If the tweak is unable to find a song or process the lyrics, you'll see a "Couldn't load the lyrics for this song" message. The lyrics might be wrong for some songs when using Genius due to how the tweak searches songs. I've made it work in most cases.
 """)) {
             Picker(
@@ -21,6 +23,7 @@ If the tweak is unable to find a song or process the lyrics, you'll see a "Could
                 Text("Genius").tag(LyricsSource.genius)
                 Text("LRCLIB").tag(LyricsSource.lrclib)
                 Text("Musixmatch").tag(LyricsSource.musixmatch)
+                Text("Petit Lyrics").tag(LyricsSource.petitLyrics)
             }
 
             if lyricsSource == .musixmatch {
@@ -60,4 +63,3 @@ If the tweak is unable to find a song or process the lyrics, you'll see a "Could
         }
     }
 }
- 

--- a/Sources/EeveeSpotify/Settings/Views/Sections/EeveeLyricsSettingsView+LyricsSourceSection.swift
+++ b/Sources/EeveeSpotify/Settings/Views/Sections/EeveeLyricsSettingsView+LyricsSourceSection.swift
@@ -12,7 +12,7 @@ LRCLIB: The most open service, offering time-synced lyrics. However, it lacks ly
 
 Musixmatch: The service Spotify uses. Provides time-synced lyrics for many songs, but you'll need a user token to use this source.
 
-Petit Lyrics: Provides lyrics from Petit Lyrics. Mostly has Japanese song lyrics. Does not provide time-synced lyrics.
+Petit Lyrics: Has a large database of Japanese and international songs. Lacks several Western songs. Does not currently support time synced.
 
 If the tweak is unable to find a song or process the lyrics, you'll see a "Couldn't load the lyrics for this song" message. The lyrics might be wrong for some songs when using Genius due to how the tweak searches songs. I've made it work in most cases.
 """)) {

--- a/Sources/EeveeSpotify/Settings/Views/Sections/EeveeLyricsSettingsView+LyricsSourceSection.swift
+++ b/Sources/EeveeSpotify/Settings/Views/Sections/EeveeLyricsSettingsView+LyricsSourceSection.swift
@@ -12,7 +12,7 @@ LRCLIB: The most open service, offering time-synced lyrics. However, it lacks ly
 
 Musixmatch: The service Spotify uses. Provides time-synced lyrics for many songs, but you'll need a user token to use this source.
 
-Petit Lyrics: Has a large database of Japanese and international songs. Lacks several Western songs. Does not currently support time synced.
+Petit Lyrics: Has a large database of time-synced Japanese and international songs. Lacks several Western songs. 
 
 If the tweak is unable to find a song or process the lyrics, you'll see a "Couldn't load the lyrics for this song" message. The lyrics might be wrong for some songs when using Genius due to how the tweak searches songs. I've made it work in most cases.
 """)) {


### PR DESCRIPTION
## Add PetitLyrics as a New Lyrics Source

### Description

This pull request introduces a new lyrics source, PetitLyrics. The addition allows users to select PetitLyrics as their preferred lyrics provider, expanding the options available for fetching lyrics. Closes https://github.com/whoeevee/EeveeSpotify/issues/243.

### Changes Made

1. **Updated Lyrics Source Section:**
   - Modified `EeveeLyricsSettingsView+LyricsSourceSection.swift` to include PetitLyrics in the lyrics source picker.
   - Updated the footer text to describe PetitLyrics.

2. **Implemented PetitLyrics Repository:**
   - Created `PetitLyricsRepository.swift` in the `/Sources/EeveeSpotify/Lyrics/Repositories` directory.
   - Implemented the `LyricsRepository` protocol for PetitLyrics.

3. **Modified Lyrics Fetching Logic:**
   - Updated `CustomLyrics.x.swift` and `LyricsSource.swift` to handle the new `.petitLyrics` case.

### Affected Files

- `Sources/EeveeSpotify/Settings/Views/Sections/EeveeLyricsSettingsView+LyricsSourceSection.swift`
- `Sources/EeveeSpotify/Lyrics/CustomLyrics.x.swift`
- `Sources/EeveeSpotify/Lyrics/Models/Settings/LyricsSource.swift`
- `Sources/EeveeSpotify/Lyrics/Repositories/PetitLyricsRepository.swift` (new file)

### Testing

- Verified that the new PetitLyrics option appears in the lyrics source picker.
- Ensured that lyrics can be fetched from PetitLyrics and displayed correctly.
- Tested fallback mechanisms to other lyrics sources when PetitLyrics fails.

### Additional Information

I had to do some hacky things because the search request sends back a full webpage, so it has to scrape it with regex, hopefully, they don't update their site often (by the looks of it they don't).
They do apparently have time synced in their app, but I couldn't get it to work with MITMProxy, to see how it's done, I may add it in the future if I can figure it out.
Please squash, if/when you merge.
Yes this is a PR description template lol.