### PR TITLE
Add task copy-swiftprotobuf to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,10 @@ EeveeSpotify_EXTRA_FRAMEWORKS = SwiftProtobuf
 EeveeSpotify_CFLAGS = -fobjc-arc -ISources/EeveeSpotifyC/include
 
 include $(THEOS_MAKE_PATH)/tweak.mk
+
+copy-swiftprotobuf:
+	mkdir -p swiftprotobuf && cd swiftprotobuf ;\
+	curl -OL https://github.com/whoeevee/EeveeSpotify/releases/download/swift2.0/org.swift.protobuf.swiftprotobuf_1.26.0_iphoneos-arm.deb ;\
+	ar -x org.swift.protobuf.swiftprotobuf_1.26.0_iphoneos-arm.deb ;\
+	tar -xvf data.tar.lzma ;\
+	cp -r Library/Frameworks/SwiftProtobuf.framework "${THEOS}/lib" ;\


### PR DESCRIPTION
This doesn't build without the `SwiftProtobuf` module, I copied the code from your CI script and put it in the `Makefile`

Simply run
```sh
make copy-swiftprotobuf
```