### PR TITLE
Tweaked French translation from 'chansons' to 'titres' to match Spotify

### DIFF
--- a/layout/Library/Application Support/EeveeSpotify.bundle/fr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/EeveeSpotify.bundle/fr.lproj/Localizable.strings
@@ -6,7 +6,7 @@ customization = "Personnalisation";
 
 common_issues_tip_title = "Des problèmes ?";
 
-common_issues_tip_message = "Si vous rencontrez un problème, comme l'impossibilité de lire des chansons, consultez";
+common_issues_tip_message = "Si vous rencontrez un problème, comme l'impossibilité de lire des titres, consultez";
 common_issues_tip_button = "Problèmes courants";
 
 reset_data = "Réinitialiser les données";
@@ -33,12 +33,12 @@ overwrite_configuration_description = "Remplacez la configuration à distance pa
 lyrics_source = "Source des paroles";
 lyrics_source_description = "Vous pouvez choisir la source des paroles que vous préférez.
 
-Genius : Offre les meilleures paroles en termes de qualité, propose le plus de chansons et met à jour les paroles le plus rapidement. Ne sera jamais synchronisé avec le temps.
+Genius : Offre les meilleures paroles en termes de qualité, propose le plus de titres et met à jour les paroles le plus rapidement. Ne sera jamais synchronisé avec le temps.
 
-LRCLIB : Le service le plus ouvert, offrant des paroles synchronisées. Cependant, il manque des paroles pour de nombreuses chansons.
+LRCLIB : Le service le plus ouvert, offrant des paroles synchronisées. Cependant, il manque des paroles pour de nombreux titres.
 
-Musixmatch : Le service utilisé par Spotify. Propose des paroles synchronisées pour de nombreuses chansons, mais vous aurez besoin d'un jeton utilisateur pour utiliser cette source.";
-lyrics_additional_info = "Si le tweak ne parvient pas à trouver une chanson ou à traiter les paroles, vous verrez le message « Impossible de charger les paroles pour cette chanson ». Les paroles peuvent être incorrectes pour certaines chansons avec Genius en raison de la façon dont le tweak recherche les chansons. J'ai fait en sorte que cela fonctionne dans la plupart des cas.";
+Musixmatch : Le service utilisé par Spotify. Propose des paroles synchronisées pour de nombreux titres, mais vous aurez besoin d'un jeton utilisateur pour utiliser cette source.";
+lyrics_additional_info = "Si le tweak ne parvient pas à trouver un titre ou à traiter les paroles, vous verrez le message « Impossible de charger les paroles de ce titre ». Les paroles peuvent être incorrectes pour certains titres avec Genius en raison de la façon dont le tweak recherche les titres. J'ai fait en sorte que cela fonctionne dans la plupart des cas.";
 petitlyrics_description = "PetitLyrics : Propose de nombreuses paroles japonaises synchronisées et quelques paroles internationales.";
 
 musixmatch_user_token = "Jeton utilisateur Musixmatch";
@@ -90,7 +90,7 @@ musixmatch_restricted_popup = "Le tweak ne peut pas charger les paroles depuis M
 
 // Errors Titles
 
-no_such_song = "Aucune chanson trouvée";
+no_such_song = "Aucun titre trouvé";
 musixmatch_restricted = "Restreint";
 invalid_musixmatch_token = "Non autorisé";
 decoding_error = "Erreur de décodage";
@@ -99,5 +99,5 @@ unknown_error = "Erreur inconnue";
 
 // Instrumental Titles
 
-song_is_instrumental = "Cette chanson est instrumentale.";
+song_is_instrumental = "Ce titre est instrumental.";
 let_the_music_play = "Laissez la musique jouer...";


### PR DESCRIPTION
It seems Spotify prefers using 'titres' in French, a more versatile term that covers both songs and other audio content. This update makes the translation more accurate and in line with their terminology.