### PR TITLE
fix: improve lyrics fetching and query encoding for special characters

### DIFF
--- a/.github/workflows/build-swift.yml
+++ b/.github/workflows/build-swift.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "swift" ]
   pull_request:
     branches: [ "swift" ]
+  workflow_dispatch: 
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ xcuserdata/
 .theos/
 packages/
 .DS_Store
+.vscode/

--- a/Sources/EeveeSpotify/Lyrics/Models/Lrclib/LrclibSong.swift
+++ b/Sources/EeveeSpotify/Lyrics/Models/Lrclib/LrclibSong.swift
@@ -4,4 +4,5 @@ struct LrclibSong: Decodable {
     var name: String
     var plainLyrics: String?
     var syncedLyrics: String?
+    var instrumental: Bool
 }

--- a/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/GeniusLyricsRepository.swift
@@ -26,9 +26,7 @@ struct GeniusLyricsRepository: LyricsRepository {
         var stringUrl = "\(apiUrl)\(path)"
 
         if !query.isEmpty {
-            let queryString = query.queryString.addingPercentEncoding(
-                withAllowedCharacters: .urlHostAllowed
-            )!
+            let queryString = query.queryString
 
             stringUrl += "?\(queryString)"
         }

--- a/Sources/EeveeSpotify/Lyrics/Repositories/LrclibLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/LrclibLyricsRepository.swift
@@ -49,23 +49,18 @@ struct LrcLibLyricsRepository: LyricsRepository {
         return data!
     }
     
-    private func searchSong(_ query: String) throws -> [LrclibSong] {
-        let data = try perform("/search", query: ["q": query])
-        return try JSONDecoder().decode([LrclibSong].self, from: data)
-    }
-    
-    //
-    
-    private func mostRelevantSong(songs: [LrclibSong], strippedTitle: String) -> LrclibSong? {
-        return songs.first(
-           where: { $0.name.containsInsensitive(strippedTitle) }
-       ) ?? songs.first
+    private func getSong(trackName: String, artistName: String) throws -> LrclibSong {
+        let data: Data = try perform("/get", query: [
+            "track_name": trackName,
+            "artist_name": artistName
+        ])
+        return try JSONDecoder().decode(LrclibSong.self, from: data)
     }
     
     private func mapSyncedLyricsLines(_ lines: [String]) -> [LyricsLineDto] {
         return lines.compactMap { line in
             guard let match = line.firstMatch(
-                "\\[(?<minute>\\d*):(?<seconds>\\d*\\.?\\d*)\\] ?(?<content>.*)"
+                "\\[(?<minute>\\d*):(?<seconds>\\d+\\.\\d+|\\d+)\\] ?(?<content>.*)"
             ) else {
                 return nil
             }
@@ -93,13 +88,27 @@ struct LrcLibLyricsRepository: LyricsRepository {
     }
 
     func getLyrics(_ query: LyricsSearchQuery, options: LyricsOptions) throws -> LyricsDto {
-        let strippedTitle = query.title.strippedTrackTitle
-        let songs = try searchSong("\(strippedTitle) \(query.primaryArtist)")
-        
-        guard let song = mostRelevantSong(songs: songs, strippedTitle: strippedTitle) else {
-            throw LyricsError.noSuchSong
+        let song: LrclibSong
+
+        do {
+            song = try getSong(trackName: query.title, artistName: query.primaryArtist)
+        } catch {
+            let strippedTitle = query.title.strippedTrackTitle
+            do {
+                song = try getSong(trackName: strippedTitle, artistName: query.primaryArtist)
+            } catch {
+                throw LyricsError.noSuchSong
+            }
         }
-        
+
+        if song.instrumental {
+            return LyricsDto(
+                lines: [],
+                timeSynced: false,
+                romanization: .original
+            )
+        }
+
         if let syncedLyrics = song.syncedLyrics {
             let lines = Array(syncedLyrics.components(separatedBy: "\n").dropLast())
             return LyricsDto(

--- a/Sources/EeveeSpotify/Lyrics/Repositories/LrclibLyricsRepository.swift
+++ b/Sources/EeveeSpotify/Lyrics/Repositories/LrclibLyricsRepository.swift
@@ -20,9 +20,7 @@ struct LrcLibLyricsRepository: LyricsRepository {
         var stringUrl = "\(apiUrl)\(path)"
 
         if !query.isEmpty {
-            let queryString = query.queryString.addingPercentEncoding(
-                withAllowedCharacters: .urlHostAllowed
-            )!
+            let queryString = query.queryString
 
             stringUrl += "?\(queryString)"
         }

--- a/Sources/EeveeSpotify/Models/Extensions/CharacterSet+Extension.swift
+++ b/Sources/EeveeSpotify/Models/Extensions/CharacterSet+Extension.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension CharacterSet {
+    static var urlQueryAllowedStrict: CharacterSet {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "/?@&=+$")
+        return allowed
+    }
+}

--- a/Sources/EeveeSpotify/Models/Extensions/Dictionary+Extension.swift
+++ b/Sources/EeveeSpotify/Models/Extensions/Dictionary+Extension.swift
@@ -3,9 +3,13 @@ import Foundation
 extension Dictionary {
     var queryString: String {
         return self
-            .compactMap({ (key, value) -> String in
-                return "\(key)=\(value)"
+            .compactMap({ (key, value) -> String? in
+                guard let keyString = "\(key)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowedStrict),
+                      let valueString = "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowedStrict) else {
+                    return nil
+                }
+                return "\(keyString)=\(valueString)"
             })
-        .joined(separator: "&")
+            .joined(separator: "&")
     }
 }


### PR DESCRIPTION
This pull request includes several changes to improve lyrics fetching.

### Changelogs

- Specific to LRCLIB

1. Use `/api/get` instead of `/api/search` for searching LRCLIB songs, in accordance with [official docs](https://lrclib.net/docs) recommendation.
2. Add a boolean property `instrumental` to the struct `LrclibSong`. Fix lyrics parser so that it returns an empty array for instrumental songs, which gets _"It is instrumental"_ correctly displayed. Before this change, empty lyrics would trigger a _Decode Error_.
3. Keep parenthesis and hyphen in the song title upon the first query. If nothing matches, fallback to a stripped title query. This ensures precise matches for songs like "Contact - Sped Up" or "Wake Me Up (Nightcore)".

- General

1. Percent-encode special characters for all keys and values in queries. This prevents query errors for songs like "He & I" or "Hello? Anyone?"

#### A Small Breaking Change: enhance 'queryString' dictionary extension

* [`Models/Extensions/CharacterSet+Extension.swift`](diffhunk://#diff-c3b70009417180aaaa59b6910cfd781ddd15cdfd85d8e2e9cc00b1c8e73be8c2R1-R9): Added a new `CharacterSet` extension to define a **stricter** set of allowed characters for URL query strings.
* [`Models/Extensions/Dictionary+Extension.swift`](diffhunk://#diff-c662ce9a66f3f814a05f581276d326057ec25b5990ac5ca02dd17996b0863f53L6-R11): Updated the `queryString` property to use the new `urlQueryAllowedStrict` character set for encoding keys and values.

### Issue Reference

Closes #411 

### Test

- My Test Method: Use GitHub workflow to build. Inject the dylib into Spotify app.
- Test Result: Lyrics from LRCLIB, Genius, and Musixmatch sources works well. Many previously failed queries can be successfully performed now, and mismatched lyrics occur much less likely.